### PR TITLE
Increase HSTS max-age to two years

### DIFF
--- a/usr/share/grommunio-common/nginx/security.conf
+++ b/usr/share/grommunio-common/nginx/security.conf
@@ -1,6 +1,6 @@
 add_header Content-Security-Policy "default-src 'self' data:; frame-src * blob:; connect-src * data: blob:; font-src * data:; img-src * data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'self'; base-uri 'self'; frame-ancestors 'self';";
 add_header Permissions-Policy "accelerometer=(), autoplay=(self), camera=(self), display-capture=(self), encrypted-media=(self), fullscreen=(self), geolocation=(self), gyroscope=(), keyboard-map=(self), magnetometer=(), microphone=(self), midi=(), payment=(), picture-in-picture=(self), publickey-credentials-get=(self), screen-wake-lock=(self), sync-xhr=(), usb=(), web-share=(self), xr-spatial-tracking=(self)";
-add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload" always;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 add_header X-Content-Type-Options nosniff;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Permitted-Cross-Domain-Policies none always;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security says:

> When using preload, the max-age directive must be at least 31536000 (1 year), and the includeSubDomains directive must be present.

Further on it says:

> [...] max-age is set to 2 years, and is suffixed with preload, which is necessary for inclusion in all major web browsers' HSTS preload lists, like Chromium, Edge, and Firefox

(https://hstspreload.org/); this also matches the common Mozilla SSL Configuration Generator recommendations at https://ssl-config.mozilla.org/.

Edit: [NCSC-NL](https://www.ncsc.nl/) ("Dutch Federal Office for Information Security") claims the same using https://internet.nl (their official tool to test the compliance with their guidelines) and indeed their guidelines themself: [Web application guideline U/WA.05 (Dutch)](https://www.ncsc.nl/documenten/publicaties/2019/mei/01/ict-beveiligingsrichtlijnen-voor-webapplicaties). And they also explain the longer max-age directive in their article “[New Internet.nl with improved tests for TLS and CSP](https://internet.nl/article/new-release-with-improved-tests-for-TLS-and-CSP/)”.