### PR TITLE
redis/grommunio.conf listen on ipv6 aswell

### DIFF
--- a/etc/redis/grommunio.conf
+++ b/etc/redis/grommunio.conf
@@ -1,4 +1,4 @@
-bind 127.0.0.1
+bind 127.0.0.1 ::1
 protected-mode yes
 port 6379
 tcp-backlog 511


### PR DESCRIPTION
I don't know if there was a change in grommunio-sync or in redis to change the behaviour but with this change it should work in either case. ref: https://community.grommunio.com/d/2862-debian-default-install-redis-error